### PR TITLE
Add drag and drop tile organization

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,6 +14,11 @@
   padding: 1rem;
   border-radius: 4px;
   width: 200px;
+  cursor: grab;
+}
+
+.device-card:active {
+  cursor: grabbing;
 }
 
 .device-card.on {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,10 +14,35 @@ export default function App() {
     { name: 'Google Home', isOn: true },
   ]);
 
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
   const toggleDevice = (index: number) => {
     setDevices((prev) =>
       prev.map((d, i) => (i === index ? { ...d, isOn: !d.isOn } : d)),
     );
+  };
+
+  const handleDragStart = (index: number) => {
+    setDraggingIndex(index);
+  };
+
+  const handleDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    index: number,
+  ) => {
+    event.preventDefault();
+    if (draggingIndex === null || draggingIndex === index) return;
+    setDevices((prev) => {
+      const updated = [...prev];
+      const [item] = updated.splice(draggingIndex, 1);
+      updated.splice(index, 0, item);
+      return updated;
+    });
+    setDraggingIndex(index);
+  };
+
+  const handleDrop = () => {
+    setDraggingIndex(null);
   };
 
   return (
@@ -25,12 +50,19 @@ export default function App() {
       <h1>Smart Home Dashboard</h1>
       <div className="devices">
         {devices.map((device, idx) => (
-          <DeviceCard
+          <div
             key={device.name}
-            name={device.name}
-            isOn={device.isOn}
-            onToggle={() => toggleDevice(idx)}
-          />
+            draggable
+            onDragStart={() => handleDragStart(idx)}
+            onDragOver={(e) => handleDragOver(e, idx)}
+            onDrop={handleDrop}
+          >
+            <DeviceCard
+              name={device.name}
+              isOn={device.isOn}
+              onToggle={() => toggleDevice(idx)}
+            />
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow rearranging tiles with drag-and-drop
- show grab cursor on device tiles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684021dee0848321b2eb2e390a08a27f