### PR TITLE
Enhance dashboard visuals with solar production chart

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.4.9",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
@@ -1214,6 +1216,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2444,6 +2452,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -4017,6 +4037,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "test": "vitest --coverage"
   },
   "dependencies": {
+    "chart.js": "^4.4.9",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,8 @@
 .container {
   font-family: Arial, sans-serif;
   padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .devices {
@@ -15,6 +17,7 @@
   border-radius: 4px;
   width: 200px;
   cursor: grab;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .device-card:active {
@@ -27,4 +30,11 @@
 
 .device-card.off {
   background-color: #ffe0e0;
+}
+
+.solar-chart {
+  margin-bottom: 2rem;
+  background: #ffffffaa;
+  padding: 1rem;
+  border-radius: 8px;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import DeviceCard from './components/DeviceCard';
+import SolarProductionChart from './components/SolarProductionChart';
 import './App.css';
 
 interface Device {
@@ -48,6 +49,7 @@ export default function App() {
   return (
     <div className="container">
       <h1>Smart Home Dashboard</h1>
+      <SolarProductionChart />
       <div className="devices">
         {devices.map((device, idx) => (
           <div

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,4 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { vi } from 'vitest'
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <canvas role="img" />,
+}))
 import App from '../App'
 import { describe, it, expect } from 'vitest'
 
@@ -15,7 +21,11 @@ describe('App', () => {
 
   it('reorders devices via drag and drop', () => {
     render(<App />)
-    const headings = () => screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent)
+    const headings = () =>
+      screen
+        .getAllByRole('heading', { level: 2 })
+        .map(h => h.textContent)
+        .filter(t => t !== 'Solar Production for Today')
     expect(headings().slice(0, 3)).toEqual([
       'Solar Panels',
       'Smart Lights',
@@ -24,6 +34,7 @@ describe('App', () => {
 
     const wrappers = screen
       .getAllByRole('heading', { level: 2 })
+      .filter(h => h.textContent !== 'Solar Production for Today')
       .map(h => h?.closest('div[draggable="true"]') as HTMLElement)
 
     fireEvent.dragStart(wrappers[0])
@@ -35,5 +46,14 @@ describe('App', () => {
       'Solar Panels',
       'Google Home',
     ])
+  })
+
+  it('renders solar production chart', () => {
+    render(<App />)
+    expect(
+      screen.getAllByRole('heading', { name: /Solar Production for Today/i })
+        .length
+    ).toBeGreaterThan(0)
+    expect(screen.getAllByTestId('solar-chart')[0].querySelector('canvas')).toBeTruthy()
   })
 })

--- a/frontend/src/components/SolarProductionChart.tsx
+++ b/frontend/src/components/SolarProductionChart.tsx
@@ -1,0 +1,45 @@
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+);
+
+const hours = Array.from({ length: 12 }, (_, i) => 6 + i); // 6am to 17pm
+const data = {
+  labels: hours.map((h) => `${h}:00`),
+  datasets: [
+    {
+      label: 'kWh',
+      data: [
+        0, 0, 1, 3, 5, 7, 6, 5, 4, 2, 1, 0,
+      ],
+      borderColor: '#ffa726',
+      backgroundColor: 'rgba(255,167,38,0.5)',
+    },
+  ],
+};
+
+export default function SolarProductionChart() {
+  return (
+    <div className="solar-chart" data-testid="solar-chart">
+      <h2>Solar Production for Today</h2>
+      <Line data={data} />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,6 +28,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: linear-gradient(135deg, #e0f7fa, #fffde7);
 }
 
 h1 {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom/vitest'
+
+// mock canvas for chart.js
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: () => null,
+})


### PR DESCRIPTION
## Summary
- add daily solar production chart component using Chart.js
- include chart in dashboard layout
- polish styles for device cards and page
- mock canvas context for tests
- update tests for new chart component

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68402518f0088321a51a0fc8665033d1